### PR TITLE
ci: use multi-stage CI for kt-MP projects

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -4,7 +4,52 @@ on:
   workflow_dispatch:
 
 jobs:
+  staging-repo:
+    runs-on: ubuntu-22.04
+    concurrency:
+      group: staging-repo
+    if: >-
+      ${{
+        !github.event.repository.fork
+        && (
+          github.event_name != 'pull_request'
+          || github.event.pull_request.head.repo.full_name == github.repository
+        )
+      }}
+    outputs:
+      maven-central-repo-id: ${{ steps.staging-repo.outputs.MavenCentral }}
+      next-version: ${{ steps.compute-next-version.outputs.next-version }}
+      will-release: ${{ steps.compute-next-version.outputs.will-release }}
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v3.3.0
+        with:
+          fetch-depth: 0
+      - uses: DanySK/build-check-deploy-gradle-action@2.1.25
+        with:
+          maven-central-password: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          should-run-codecov: false
+          should-deploy: true
+          build-command: true
+          check-command: true
+          deploy-command: ./gradlew createStagingRepositoryOnMavenCentral --parallel
+      - name: Save staging repository ID
+        id: staging-repo
+        run: |
+          [[ -f build/staging-repo-ids.properties ]] || (
+            echo "Staging repositories ID file not found" &&
+            exit 1
+          )
+          REPO_IDS=$(cat build/staging-repo-ids.properties)
+          echo "Staging repositories IDs:\n$REPO_IDS"
+          echo $REPO_IDS >> $GITHUB_OUTPUT
+      - name: Compute next release version
+        id: compute-next-version
+        uses: nicolasfara/precompute-semantic-release-version-action@1.0.1
+        with:
+          github-token: ${{ github.token }}
   build:
+    needs: [ staging-repo ]
     strategy:
       matrix:
         os: [ windows-2022, macos-12, ubuntu-22.04 ]
@@ -19,12 +64,13 @@ jobs:
         with:
           # Dry-deployment
           deploy-command: >-
-            ./gradlew uploadAll close --parallel
+            NEXT_VERSION="${{ needs.staging-repo.outputs.next-version }}"
+            OVERRIDE_VERSION=$([[ "$NEXT_VERSION" != "" ]] && echo "-PforceVersion=$(echo $NEXT_VERSION)" || echo "")
+            ./gradlew $OVERRIDE_VERSION -PstagingRepositoryId=${{ needs.staging-repo.outputs.maven-central-repo-id }} uploadAll --parallel
           should-run-codecov: ${{ runner.os == 'Linux' }}
           should-deploy: >-
             ${{
-              runner.os == 'macOS'
-              && !github.event.repository.fork
+              !github.event.repository.fork
               && (
                 github.event_name != 'pull_request'
                 || github.event.pull_request.head.repo.full_name == github.repository
@@ -33,6 +79,31 @@ jobs:
           maven-central-password: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
           signing-key: ${{ secrets.SIGNING_KEY }}
           signing-password: ${{ secrets.SIGNING_PASSWORD }}
+  close-staging-repos:
+    needs: [ staging-repo, build ]
+    runs-on: ubuntu-22.04
+    concurrency:
+      group: close-staging-repos
+    if: >-
+      ${{
+        !github.event.repository.fork
+        && (
+          github.event_name != 'pull_request'
+          || github.event.pull_request.head.repo.full_name == github.repository
+        )
+      }}
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v3.3.0
+      - uses: DanySK/build-check-deploy-gradle-action@2.1.25
+        with:
+          maven-central-password: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          should-run-codecov: false
+          should-deploy: true
+          build-command: true
+          check-command: true
+          deploy-command: >-
+            ./gradlew -PstagingRepositoryId=${{ needs.staging-repo.outputs.maven-central-repo-id }} close --parallel
   release:
     concurrency:
       # Only one release job at a time per branch, as only master releases.
@@ -40,13 +111,15 @@ jobs:
       group: release-${{ github.event.number || github.ref }}
     needs:
       - build
-    runs-on: macos-12
+    runs-on: ubuntu-22.04
     if: >-
-      !github.event.repository.fork
-      && (
-        github.event_name != 'pull_request'
-        || github.event.pull_request.head.repo.full_name == github.repository
-      )
+      ${{
+        !github.event.repository.fork
+        && (
+          github.event_name != 'pull_request'
+          || github.event.pull_request.head.repo.full_name == github.repository
+        )
+      }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3.3.0
@@ -61,6 +134,7 @@ jobs:
           node-version: ${{ steps.node-version.outputs.version }}
       - uses: DanySK/build-check-deploy-gradle-action@2.1.26
         env:
+          STAGING_REPO_ID: ${{ needs.staging-repo.outputs.maven-central-repo-id }}
           ORG_GRADLE_PROJECT_releaseStage: true
         with:
           build-command: true
@@ -78,6 +152,8 @@ jobs:
   success:
     runs-on: ubuntu-22.04
     needs:
+      - staging-repo
+      - close-staging-repos
       - release
       - build
     if: >-

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -100,8 +100,12 @@ jobs:
           should-deploy: true
           build-command: true
           check-command: true
-          deploy-command: >-
+          deploy-command: |
             ./gradlew -PstagingRepositoryId=${{ needs.staging-repo.outputs.maven-central-repo-id }} close --parallel
+            if [[ "${{ needs.staging-repo.outputs.will-release }}" == "false" ]]; then
+              ./gradlew -PstagingRepositoryId=${{ needs.staging-repo.outputs.maven-central-repo-id }} drop
+            fi
+
   release:
     concurrency:
       # Only one release job at a time per branch, as only master releases.

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set condition
         id: require-secrets
         run: |
-          echo "run-with-secrets=${{ steps.detect-secrets.outputs.has-secrets == 'true' && github.event.repository.fork == 'false' }}" >> $GITHUB_OUTPUT
+          echo "run-with-secrets=${{ steps.detect-secrets.outputs.has-secrets == 'true' && !github.event.repository.fork }}" >> $GITHUB_OUTPUT
 
   staging-repo:
     runs-on: ubuntu-22.04

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -4,18 +4,28 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-secrets:
+    runs-on: ubuntu-22.04
+    outputs:
+      run-with-secrets: ${{ steps.require-secrets.outputs.run-with-secrets }}
+    steps:
+      - name: Find if secrets are available
+        id: detect-secrets
+        uses: DanySK/are-secrets-available@1.0.0
+        with:
+          secrets: ${{ toJson(secrets) }}
+      - name: Set condition
+        id: require-secrets
+        run: |
+          echo "run-with-secrets=${{ steps.detect-secrets.outputs.has-secrets == 'true' && github.event.repository.fork == 'false' }}" >> $GITHUB_OUTPUT
+
   staging-repo:
     runs-on: ubuntu-22.04
+    needs:
+      - check-secrets
     concurrency:
       group: staging-repo
-    if: >-
-      ${{
-        !github.event.repository.fork
-        && (
-          github.event_name != 'pull_request'
-          || github.event.pull_request.head.repo.full_name == github.repository
-        )
-      }}
+    if: ${{ needs.check-secrets.outputs.run-with-secrets == 'true' }}
     outputs:
       maven-central-repo-id: ${{ steps.staging-repo.outputs.MavenCentral }}
       next-version: ${{ steps.compute-next-version.outputs.next-version }}
@@ -49,7 +59,9 @@ jobs:
         with:
           github-token: ${{ github.token }}
   build:
-    needs: [ staging-repo ]
+    needs:
+      - staging-repo
+    if: ${{ always() && !contains(needs.staging-repo.result, 'failure') }}
     strategy:
       matrix:
         os: [ windows-2022, macos-12, ubuntu-22.04 ]
@@ -68,14 +80,7 @@ jobs:
             OVERRIDE_VERSION=$([[ "$NEXT_VERSION" != "" ]] && echo "-PforceVersion=$(echo $NEXT_VERSION)" || echo "")
             ./gradlew $OVERRIDE_VERSION -PstagingRepositoryId=${{ needs.staging-repo.outputs.maven-central-repo-id }} uploadAll --parallel
           should-run-codecov: ${{ runner.os == 'Linux' }}
-          should-deploy: >-
-            ${{
-              !github.event.repository.fork
-              && (
-                github.event_name != 'pull_request'
-                || github.event.pull_request.head.repo.full_name == github.repository
-              )
-            }}
+          should-deploy: ${{ needs.check-secrets.outputs.run-with-secrets == 'true' }}
           maven-central-password: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
           signing-key: ${{ secrets.SIGNING_KEY }}
           signing-password: ${{ secrets.SIGNING_PASSWORD }}
@@ -84,14 +89,7 @@ jobs:
     runs-on: ubuntu-22.04
     concurrency:
       group: close-staging-repos
-    if: >-
-      ${{
-        !github.event.repository.fork
-        && (
-          github.event_name != 'pull_request'
-          || github.event.pull_request.head.repo.full_name == github.repository
-        )
-      }}
+    if: ${{ needs.check-secrets.outputs.run-with-secrets == 'true' }}
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v3.3.0
@@ -111,15 +109,9 @@ jobs:
       group: release-${{ github.event.number || github.ref }}
     needs:
       - build
+      - close-staging-repos
     runs-on: ubuntu-22.04
-    if: >-
-      ${{
-        !github.event.repository.fork
-        && (
-          github.event_name != 'pull_request'
-          || github.event.pull_request.head.repo.full_name == github.repository
-        )
-      }}
+    if: ${{ needs.check-secrets.outputs.run-with-secrets == 'true' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3.3.0
@@ -152,6 +144,7 @@ jobs:
   success:
     runs-on: ubuntu-22.04
     needs:
+      - check-secrets
       - staging-repo
       - close-staging-repos
       - release

--- a/release.config.js
+++ b/release.config.js
@@ -1,7 +1,6 @@
 var publishCmd = `
-./gradlew uploadAllPublicationsToMavenCentralNexus releaseStagingRepositoryOnMavenCentral || exit 3
+./gradlew -PstagingRepositoryId=\${process.env.STAGING_REPO_ID} releaseStagingRepositoryOnMavenCentral || exit 3
 ./gradlew publishJsPackageToNpmjsRegistry || exit 4
-./gradlew publishKotlinMultiplatformPublicationToGithubRepository || true
 `
 var config = require('semantic-release-preconfigured-conventional-commits');
 config.plugins.push(


### PR DESCRIPTION
This PR refactors the CI to have a multi-stage build (using all three runners instead of building all from macOS).